### PR TITLE
Add ruby to gemfile to try and resolve build error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     yaml (0.3.0)
 
 PLATFORMS
+  ruby
   x64-mingw-ucrt
   x86_64-linux-gnu
 


### PR DESCRIPTION
Trying to resolve build error. Noticed that other hp forks have 'ruby' listed under their platforms.